### PR TITLE
Fix `matrix' dependency and unit test filespec.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem "rspec", "~> 3.0"
 gem "httparty"
 gem "numo-narray"
 gem "faiss"
+gem "matrix"
 gem "mistral-ai"
 gem "zeitwerk", "~> 2.6", ">= 2.6.11"
 gem "dotenv", groups: [:development, :test]

--- a/spec/index_spec.rb
+++ b/spec/index_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe SimpleRag::Index do
       result = index.load(url)
 
       expect(HTTParty).to have_received(:get).with(url)
-      expect(File).to have_received(:write).with(file_path, response_body)
+      expect(File).to have_received(:write).with(/#{file_path}$/, response_body)
       expect(result).to eq(response_body)
     end
   end


### PR DESCRIPTION
This PR fixes 2 issues:

1) 'matrix' gem required but not included in Gemfile. I added it to the Gemfile. It is not currently used, but I am assuming it will be.
1) a unit test failed because it was expecting a filespec to be relative but it was absolute. The test was changed to use a regex to ensure that the filespec _ended_ with the relative path.
